### PR TITLE
Add mini player and volume booster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "youtube-tweak",
-	"version": "1.1.4",
+	"version": "1.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "youtube-tweak",
-			"version": "1.1.4",
+			"version": "1.1.6",
 			"hasInstallScript": true,
 			"dependencies": {
 				"pinia": "^3.0.3",
@@ -22,6 +22,7 @@
 				"dotenv": "^17.2.3",
 				"prettier": "^3.6.2",
 				"sass": "^1.91.0",
+				"tsx": "^4.20.6",
 				"typescript": "5.9.2",
 				"vite-plugin-vue-devtools": "^8.0.1",
 				"vue-tsc": "^3.0.6",
@@ -1075,6 +1076,23 @@
 			"optional": true,
 			"os": [
 				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
 			],
 			"engines": {
 				"node": ">=18"
@@ -7298,6 +7316,492 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+			"integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tsx/node_modules/esbuild": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
+			}
 		},
 		"node_modules/type-fest": {
 			"version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"dotenv": "^17.2.3",
 		"prettier": "^3.6.2",
 		"sass": "^1.91.0",
+		"tsx": "^4.20.6",
 		"typescript": "5.9.2",
 		"vite-plugin-vue-devtools": "^8.0.1",
 		"vue-tsc": "^3.0.6",

--- a/src/assets/i18n/ar-SA.json
+++ b/src/assets/i18n/ar-SA.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "الزاوية السفلية اليسرى",
 				"bottomRight": "الزاوية السفلية اليمنى",
 				"topLeft": "الزاوية العلوية اليسرى",
-				"topRight": "الزاوية العلوية اليمنى"
+				"topRight": "الزاوية العلوية اليمنى",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "ملصقات وقت الفيديو العائمة",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "تفعيل زر تدوير الفيديو",
 				"enableMirrorButton": "تفعيل زر عكس الفيديو"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/bn-BD.json
+++ b/src/assets/i18n/bn-BD.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "নিচের বাম কোণা",
 				"bottomRight": "নিচের ডান কোণা",
 				"topLeft": "উপরের বাম কোণা",
-				"topRight": "উপরের ডান কোণা"
+				"topRight": "উপরের ডান কোণা",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "ভাসমান ভিডিও সময় ট্যাগ",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "ভিডিও ঘোরানোর বোতাম সক্রিয় করুন",
 				"enableMirrorButton": "ভিডিও মিরর করার বোতাম সক্রিয় করুন"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/de-DE.json
+++ b/src/assets/i18n/de-DE.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Unten links",
 				"bottomRight": "Unten rechts",
 				"topLeft": "Oben links",
-				"topRight": "Oben rechts"
+				"topRight": "Oben rechts",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Schwebende Videozeit",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Schaltfläche zum Drehen des Videos aktivieren",
 				"enableMirrorButton": "Schaltfläche zum Spiegeln des Videos aktivieren"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Bottom-left corner",
 				"bottomRight": "Bottom-right corner",
 				"topLeft": "Top-left corner",
-				"topRight": "Top-right corner"
+				"topRight": "Top-right corner",
+				"bottomCenter": "Bottom-center",
+				"topCenter": "Top-center"
 			},
 			"tips": {
 				"timeTag": "Floating video time tags",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Enable video rotation button",
 				"enableMirrorButton": "Enable video mirror button"
+			}
+		},
+		"volumeBooster": {
+			"title": "Volume booster",
+			"checkbox": {
+				"showControl": "Show booster control beside the speed strip",
+				"enableByDefault": "Enable booster by default"
+			},
+			"select": {
+				"multiplier": "Boost level"
+			},
+			"tips": {
+				"control": "Adds a real gain stage above YouTube's built-in 100% volume. Use the in-player button to toggle it instantly."
+			}
+		},
+		"miniPlayer": {
+			"title": "Scroll mini-player",
+			"checkbox": {
+				"enable": "Keep playing in a floating mini-player while scrolling"
+			},
+			"select": {
+				"size": "Size",
+				"position": "Position",
+				"offset": "Screen margin (px)",
+				"triggerOffset": "Activate after scrolling past player (px)"
+			},
+			"tips": {
+				"enable": "Float the current video while you scroll. Dismiss it from the player anytime."
 			}
 		}
 	},

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Esquina inferior izquierda",
 				"bottomRight": "Esquina inferior derecha",
 				"topLeft": "Esquina superior izquierda",
-				"topRight": "Esquina superior derecha"
+				"topRight": "Esquina superior derecha",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Etiquetas de tiempo flotantes",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Habilitar botón de rotación del video",
 				"enableMirrorButton": "Habilitar botón de espejo del video"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/fa-IR.json
+++ b/src/assets/i18n/fa-IR.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "گوشه چپ پایین",
 				"bottomRight": "گوشه راست پایین",
 				"topLeft": "گوشه چپ بالا",
-				"topRight": "گوشه راست بالا"
+				"topRight": "گوشه راست بالا",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "برچسب زمان شناور ویدیو",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "فعال کردن دکمه چرخش ویدیو",
 				"enableMirrorButton": "فعال کردن دکمه آینه کردن ویدیو"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/fr-FR.json
+++ b/src/assets/i18n/fr-FR.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Coin inférieur gauche",
 				"bottomRight": "Coin inférieur droit",
 				"topLeft": "Coin supérieur gauche",
-				"topRight": "Coin supérieur droit"
+				"topRight": "Coin supérieur droit",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Étiquettes de temps vidéo flottantes",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Activer le bouton de rotation de la vidéo",
 				"enableMirrorButton": "Activer le bouton de miroir de la vidéo"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/hi-IN.json
+++ b/src/assets/i18n/hi-IN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "बायां निचला कोना",
 				"bottomRight": "दायां निचला कोना",
 				"topLeft": "बायां ऊपरी कोना",
-				"topRight": "दायां ऊपरी कोना"
+				"topRight": "दायां ऊपरी कोना",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "तैरते वीडियो समय टैग",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "वीडियो घुमाने का बटन सक्षम करें",
 				"enableMirrorButton": "वीडियो मिरर करने का बटन सक्षम करें"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/id-ID.json
+++ b/src/assets/i18n/id-ID.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Sudut kiri bawah",
 				"bottomRight": "Sudut kanan bawah",
 				"topLeft": "Sudut kiri atas",
-				"topRight": "Sudut kanan atas"
+				"topRight": "Sudut kanan atas",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Label waktu video mengambang",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Aktifkan tombol rotasi video",
 				"enableMirrorButton": "Aktifkan tombol mirror video"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/it-IT.json
+++ b/src/assets/i18n/it-IT.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Angolo in basso a sinistra",
 				"bottomRight": "Angolo in basso a destra",
 				"topLeft": "Angolo in alto a sinistra",
-				"topRight": "Angolo in alto a destra"
+				"topRight": "Angolo in alto a destra",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Etichetta tempo video fluttuante",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Abilita pulsante di rotazione video",
 				"enableMirrorButton": "Abilita pulsante specchia video"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/ja-JP.json
+++ b/src/assets/i18n/ja-JP.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "左下隅",
 				"bottomRight": "右下隅",
 				"topLeft": "左上隅",
-				"topRight": "右上隅"
+				"topRight": "右上隅",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "浮動表示の動画時間",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "動画の回転ボタンを有効にする",
 				"enableMirrorButton": "動画のミラーボタンを有効にする"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/ko-KR.json
+++ b/src/assets/i18n/ko-KR.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "왼쪽 아래 모서리",
 				"bottomRight": "오른쪽 아래 모서리",
 				"topLeft": "왼쪽 위 모서리",
-				"topRight": "오른쪽 위 모서리"
+				"topRight": "오른쪽 위 모서리",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "떠 있는 영상 시간 태그",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "회전 버튼 사용",
 				"enableMirrorButton": "좌우 반전 버튼 사용"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/mr-IN.json
+++ b/src/assets/i18n/mr-IN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "खालचा डावा कोपरा",
 				"bottomRight": "खालचा उजवा कोपरा",
 				"topLeft": "वरचा डावा कोपरा",
-				"topRight": "वरचा उजवा कोपरा"
+				"topRight": "वरचा उजवा कोपरा",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "तरंगणारे व्हिडिओ वेळ टॅग",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "व्हिडिओ फिरविण्याचे बटण सक्षम करा",
 				"enableMirrorButton": "व्हिडिओ मिरर बटण सक्षम करा"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/ms-MY.json
+++ b/src/assets/i18n/ms-MY.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Sudut kiri bawah",
 				"bottomRight": "Sudut kanan bawah",
 				"topLeft": "Sudut kiri atas",
-				"topRight": "Sudut kanan atas"
+				"topRight": "Sudut kanan atas",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Tag masa video terapung",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Aktifkan butang putar video",
 				"enableMirrorButton": "Aktifkan butang cermin video"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/pa-PK.json
+++ b/src/assets/i18n/pa-PK.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "کھبّا ہِٹھّلا کونا",
 				"bottomRight": "سجّا ہِٹھّلا کونا",
 				"topLeft": "کھبّا اُپرلا کونا",
-				"topRight": "سجّا اُپرلا کونا"
+				"topRight": "سجّا اُپرلا کونا",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "تیرتا ویڈیو ویلہ ٹیگ",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "ویڈیو گھماؤن والا بٹن فعال کرو",
 				"enableMirrorButton": "ویڈیو دا عکس والا بٹن فعال کرو"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/pt-BR.json
+++ b/src/assets/i18n/pt-BR.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Canto inferior esquerdo",
 				"bottomRight": "Canto inferior direito",
 				"topLeft": "Canto superior esquerdo",
-				"topRight": "Canto superior direito"
+				"topRight": "Canto superior direito",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Tempo de vídeo flutuante",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Ativar botão de rotação do vídeo",
 				"enableMirrorButton": "Ativar botão de espelhamento do vídeo"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/ru-RU.json
+++ b/src/assets/i18n/ru-RU.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Нижний левый угол",
 				"bottomRight": "Нижний правый угол",
 				"topLeft": "Верхний левый угол",
-				"topRight": "Верхний правый угол"
+				"topRight": "Верхний правый угол",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Плавающие метки времени видео",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Включить кнопку поворота видео",
 				"enableMirrorButton": "Включить кнопку зеркального отражения видео"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/ta-IN.json
+++ b/src/assets/i18n/ta-IN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "இடது கீழ் மூலை",
 				"bottomRight": "வலது கீழ் மூலை",
 				"topLeft": "இடது மேல் மூலை",
-				"topRight": "வலது மேல் மூலை"
+				"topRight": "வலது மேல் மூலை",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "மிதக்கும் வீடியோ நேர குறிச்சொற்கள்",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "வீடியோ சுழற்சி பொத்தானை இயக்கு",
 				"enableMirrorButton": "வீடியோ கண்ணாடி பொத்தானை இயக்கு"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/te-IN.json
+++ b/src/assets/i18n/te-IN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "ఎడమ క్రింది మూల",
 				"bottomRight": "కుడి క్రింది మూల",
 				"topLeft": "ఎడమ పై మూల",
-				"topRight": "కుడి పై మూల"
+				"topRight": "కుడి పై మూల",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "తేలియాడే వీడియో సమయ ట్యాగ్",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "వీడియో రొటేషన్ బటన్ను ప్రారంభించు",
 				"enableMirrorButton": "వీడియో మిర్రర్ బటన్ను ప్రారంభించు"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/th-TH.json
+++ b/src/assets/i18n/th-TH.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "มุมซ้ายล่าง",
 				"bottomRight": "มุมขวาล่าง",
 				"topLeft": "มุมซ้ายบน",
-				"topRight": "มุมขวาบน"
+				"topRight": "มุมขวาบน",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "ป้ายเวลาแบบลอย",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "เปิดปุ่มหมุนวิดีโอ",
 				"enableMirrorButton": "เปิดปุ่มกลับด้านกระจก"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/tr-TR.json
+++ b/src/assets/i18n/tr-TR.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Sol alt köşe",
 				"bottomRight": "Sağ alt köşe",
 				"topLeft": "Sol üst köşe",
-				"topRight": "Sağ üst köşe"
+				"topRight": "Sağ üst köşe",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Yüzen video süre etiketi",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Video döndürme düğmesini etkinleştir",
 				"enableMirrorButton": "Video ayna düğmesini etkinleştir"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/uk-UA.json
+++ b/src/assets/i18n/uk-UA.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Нижній лівий кут",
 				"bottomRight": "Нижній правий кут",
 				"topLeft": "Верхній лівий кут",
-				"topRight": "Верхній правий кут"
+				"topRight": "Верхній правий кут",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Спливаючі мітки часу відео",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Увімкнути кнопку обертання відео",
 				"enableMirrorButton": "Увімкнути кнопку дзеркала відео"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/vi-VN.json
+++ b/src/assets/i18n/vi-VN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "Góc dưới bên trái",
 				"bottomRight": "Góc dưới bên phải",
 				"topLeft": "Góc trên bên trái",
-				"topRight": "Góc trên bên phải"
+				"topRight": "Góc trên bên phải",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "Nhãn thời gian nổi",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "Bật nút xoay video",
 				"enableMirrorButton": "Bật nút lật gương video"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "左下角",
 				"bottomRight": "右下角",
 				"topLeft": "左上角",
-				"topRight": "右上角"
+				"topRight": "右上角",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "悬浮视频时间",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "启用旋转视频按钮",
 				"enableMirrorButton": "启用镜像视频按钮"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/assets/i18n/zh-TW.json
+++ b/src/assets/i18n/zh-TW.json
@@ -84,7 +84,9 @@
 				"bottomLeft": "左下角",
 				"bottomRight": "右下角",
 				"topLeft": "左上角",
-				"topRight": "右上角"
+				"topRight": "右上角",
+				"bottomCenter": "__NEED_TRANSLATE__",
+				"topCenter": "__NEED_TRANSLATE__"
 			},
 			"tips": {
 				"timeTag": "浮動影片時間",
@@ -103,6 +105,34 @@
 			"checkbox": {
 				"enableRotateButton": "啟用旋轉影片按鈕",
 				"enableMirrorButton": "啟用鏡像影片按鈕"
+			}
+		},
+		"volumeBooster": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"showControl": "__NEED_TRANSLATE__",
+				"enableByDefault": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"multiplier": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"control": "__NEED_TRANSLATE__"
+			}
+		},
+		"miniPlayer": {
+			"title": "__NEED_TRANSLATE__",
+			"checkbox": {
+				"enable": "__NEED_TRANSLATE__"
+			},
+			"select": {
+				"size": "__NEED_TRANSLATE__",
+				"position": "__NEED_TRANSLATE__",
+				"offset": "__NEED_TRANSLATE__",
+				"triggerOffset": "__NEED_TRANSLATE__"
+			},
+			"tips": {
+				"enable": "__NEED_TRANSLATE__"
 			}
 		}
 	},

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -12,7 +12,6 @@ enum VideoQuality {
 
 type MiniPlayerSize = "360x203" | "420x236" | "480x270" | "560x315" | "640x360" | "720x405";
 type MiniPlayerPosition = "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
-type VolumeBoosterMultiplier = 1.25 | 1.5 | 1.75 | 2 | 2.5 | 3 | 4 | 5;
 
 export type Config = {
 	"player.ui.enableSpeedButtons": boolean;
@@ -47,7 +46,7 @@ export type Config = {
 	"player.settings.saveSubtitleStatusByChannel": boolean;
 	"player.settings.nonStop": boolean;
 	"player.settings.volumeBooster": boolean;
-	"player.settings.volumeBoosterMultiplier": VolumeBoosterMultiplier;
+	"player.settings.volumeBoosterMultiplier": number;
 	"player.ui.functionButtons.enableRotateButton": boolean;
 	"player.ui.functionButtons.enableMirrorButton": boolean;
 

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -10,9 +10,14 @@ enum VideoQuality {
 	tiny = "144p",
 }
 
+type MiniPlayerSize = "360x203" | "420x236" | "480x270" | "560x315" | "640x360" | "720x405";
+type MiniPlayerPosition = "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
+type VolumeBoosterMultiplier = 1.25 | 1.5 | 1.75 | 2 | 2.5 | 3 | 4 | 5;
+
 export type Config = {
 	"player.ui.enableSpeedButtons": boolean;
 	"player.ui.speedButtons": Array<0.25 | 0.5 | 0.75 | 1 | 1.25 | 1.5 | 1.75 | 2 | 2.25 | 2.5 | 2.75 | 3 | 5 | 10>;
+	"player.ui.enableVolumeBooster": boolean;
 	"player.ui.hideButton.autoplay": boolean;
 	"player.ui.hideButton.subtitles": boolean;
 	"player.ui.hideButton.settings": boolean;
@@ -28,6 +33,11 @@ export type Config = {
 	"player.ui.progress.tagFontSize": number;
 	"player.ui.progress.tagPosition": "bottom-left" | "bottom-right" | "top-left" | "top-right";
 	"player.ui.progress.tagOffset": number;
+	"player.miniPlayer.enable": boolean;
+	"player.miniPlayer.size": MiniPlayerSize;
+	"player.miniPlayer.position": MiniPlayerPosition;
+	"player.miniPlayer.offset": number;
+	"player.miniPlayer.triggerOffset": number;
 	"player.settings.maxVolume": boolean;
 	"player.settings.lockQuality": boolean;
 	"player.settings.lockQuality.value": keyof typeof VideoQuality;
@@ -36,6 +46,8 @@ export type Config = {
 	"player.settings.saveSubtitleStatus": boolean;
 	"player.settings.saveSubtitleStatusByChannel": boolean;
 	"player.settings.nonStop": boolean;
+	"player.settings.volumeBooster": boolean;
+	"player.settings.volumeBoosterMultiplier": VolumeBoosterMultiplier;
 	"player.ui.functionButtons.enableRotateButton": boolean;
 	"player.ui.functionButtons.enableMirrorButton": boolean;
 
@@ -62,6 +74,7 @@ export type Config = {
 const config: Config = {
 	"player.ui.enableSpeedButtons": true,
 	"player.ui.speedButtons": [0.5, 1, 1.5, 2],
+	"player.ui.enableVolumeBooster": true,
 	"player.ui.hideButton.autoplay": false,
 	"player.ui.hideButton.subtitles": false,
 	"player.ui.hideButton.settings": false,
@@ -77,6 +90,11 @@ const config: Config = {
 	"player.ui.progress.tagFontSize": 12,
 	"player.ui.progress.tagPosition": "bottom-left",
 	"player.ui.progress.tagOffset": 5,
+	"player.miniPlayer.enable": false,
+	"player.miniPlayer.size": "480x270",
+	"player.miniPlayer.position": "bottom-right",
+	"player.miniPlayer.offset": 16,
+	"player.miniPlayer.triggerOffset": 48,
 	"player.settings.maxVolume": true,
 	"player.settings.lockQuality": false,
 	"player.settings.lockQuality.value": "hd1080",
@@ -85,6 +103,8 @@ const config: Config = {
 	"player.settings.saveSubtitleStatus": true,
 	"player.settings.saveSubtitleStatusByChannel": true,
 	"player.settings.nonStop": true,
+	"player.settings.volumeBooster": false,
+	"player.settings.volumeBoosterMultiplier": 2,
 	"player.ui.functionButtons.enableRotateButton": false,
 	"player.ui.functionButtons.enableMirrorButton": false,
 

--- a/src/entrypoints/popup/components/player/MiniPlayerSettingsCard.vue
+++ b/src/entrypoints/popup/components/player/MiniPlayerSettingsCard.vue
@@ -1,0 +1,71 @@
+<template>
+	<div class="card">
+		<div class="card-title">{{ $t("player.miniPlayer.title") }}</div>
+		<div class="card-body">
+			<label class="form-item">
+				<input type="checkbox" v-model="config['player.miniPlayer.enable']" />
+				<span>{{ $t("player.miniPlayer.checkbox.enable") }}</span>
+			</label>
+
+			<p>{{ $t("player.miniPlayer.tips.enable") }}</p>
+
+			<label class="form-item form-item-select">
+				<span>{{ $t("player.miniPlayer.select.size") }}</span>
+				<select class="w-100" v-model="config['player.miniPlayer.size']">
+					<option v-for="option in sizeOptions" :key="option.value" :value="option.value">
+						{{ option.label }}
+					</option>
+				</select>
+			</label>
+
+			<label class="form-item form-item-select">
+				<span>{{ $t("player.miniPlayer.select.position") }}</span>
+				<select class="w-100" v-model="config['player.miniPlayer.position']">
+					<option v-for="option in positionOptions" :key="option.value" :value="option.value">
+						{{ option.arrow }} {{ $t(option.labelKey) }}
+					</option>
+				</select>
+			</label>
+
+			<label class="form-item form-item-select">
+				<span>{{ $t("player.miniPlayer.select.offset") }}</span>
+				<input type="number" min="0" max="96" style="width: 90px" v-model.number="config['player.miniPlayer.offset']" />
+			</label>
+
+			<label class="form-item form-item-select">
+				<span>{{ $t("player.miniPlayer.select.triggerOffset") }}</span>
+				<input
+					type="number"
+					min="0"
+					max="400"
+					style="width: 90px"
+					v-model.number="config['player.miniPlayer.triggerOffset']"
+				/>
+			</label>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import useConfigStore from "../../util/config";
+
+const config = useConfigStore();
+
+const sizeOptions = [
+	{ value: "360x203", label: "Compact 360×203" },
+	{ value: "420x236", label: "Balanced 420×236" },
+	{ value: "480x270", label: "Default 480×270" },
+	{ value: "560x315", label: "Large 560×315" },
+	{ value: "640x360", label: "XL 640×360" },
+	{ value: "720x405", label: "Cinema 720×405" },
+];
+
+const positionOptions = [
+	{ value: "bottom-right", labelKey: "player.ui.position.bottomRight", arrow: "↘" },
+	{ value: "bottom-center", labelKey: "player.ui.position.bottomCenter", arrow: "↓" },
+	{ value: "bottom-left", labelKey: "player.ui.position.bottomLeft", arrow: "↙" },
+	{ value: "top-right", labelKey: "player.ui.position.topRight", arrow: "↗" },
+	{ value: "top-center", labelKey: "player.ui.position.topCenter", arrow: "↑" },
+	{ value: "top-left", labelKey: "player.ui.position.topLeft", arrow: "↖" },
+];
+</script>

--- a/src/entrypoints/popup/components/player/VolumeBoosterSettingsCard.vue
+++ b/src/entrypoints/popup/components/player/VolumeBoosterSettingsCard.vue
@@ -1,0 +1,37 @@
+<template>
+	<div class="card">
+		<div class="card-title">{{ $t("player.volumeBooster.title") }}</div>
+		<div class="card-body">
+			<label class="form-item">
+				<input type="checkbox" v-model="config['player.ui.enableVolumeBooster']" />
+				<span>{{ $t("player.volumeBooster.checkbox.showControl") }}</span>
+			</label>
+
+			<label class="form-item">
+				<input type="checkbox" v-model="config['player.settings.volumeBooster']" />
+				<span>{{ $t("player.volumeBooster.checkbox.enableByDefault") }}</span>
+			</label>
+
+			<p>{{ $t("player.volumeBooster.tips.control") }}</p>
+
+			<label class="form-item form-item-select">
+				<span>{{ $t("player.volumeBooster.select.multiplier") }}</span>
+				<select class="w-100" v-model.number="config['player.settings.volumeBoosterMultiplier']">
+					<option v-for="option in multiplierOptions" :key="option" :value="option">{{ formatMultiplier(option) }}x</option>
+				</select>
+			</label>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import useConfigStore from "../../util/config";
+
+const config = useConfigStore();
+
+const multiplierOptions = [1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5];
+
+function formatMultiplier(value: number) {
+	return value.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+}
+</script>

--- a/src/entrypoints/popup/components/player/VolumeBoosterSettingsCard.vue
+++ b/src/entrypoints/popup/components/player/VolumeBoosterSettingsCard.vue
@@ -29,9 +29,12 @@ import useConfigStore from "../../util/config";
 
 const config = useConfigStore();
 
-const multiplierOptions = [1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5];
+const multiplierOptions = Array.from({ length: 16 }, (_, index) => 1.25 + index * 0.25);
 
 function formatMultiplier(value: number) {
-	return value.toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+	return value
+		.toFixed(2)
+		.replace(/\.00$/, "")
+		.replace(/(\.\d)0$/, "$1");
 }
 </script>

--- a/src/entrypoints/popup/pages/player.vue
+++ b/src/entrypoints/popup/pages/player.vue
@@ -61,6 +61,7 @@
 				</label>
 			</div>
 		</div>
+		<VolumeBoosterSettingsCard />
 		<div class="card">
 			<div class="card-title">{{ $t("player.subtitles.title") }}</div>
 			<div class="card-body">
@@ -101,6 +102,7 @@
 				</label>
 			</div>
 		</div>
+		<MiniPlayerSettingsCard />
 		<div class="card">
 			<div class="card-title">{{ $t("player.ui.title") }}</div>
 			<div class="card-body">
@@ -157,6 +159,8 @@
 </template>
 
 <script setup lang="ts">
+import MiniPlayerSettingsCard from "../components/player/MiniPlayerSettingsCard.vue";
+import VolumeBoosterSettingsCard from "../components/player/VolumeBoosterSettingsCard.vue";
 import useConfigStore from "../util/config";
 const config = useConfigStore() as {
 	[key: `player.ui.hideButton.${string}`]: boolean;

--- a/src/inject/plugins/player-miniPlayer.scss
+++ b/src/inject/plugins/player-miniPlayer.scss
@@ -1,0 +1,225 @@
+body.yttweak-mini-player-mode ytd-player,
+body.yttweak-mini-player-mode #player,
+body.yttweak-mini-player-mode #player-container,
+body.yttweak-mini-player-mode #full-bleed-container,
+body.yttweak-mini-player-mode #player-full-bleed-container {
+	overflow: visible !important;
+	z-index: auto !important;
+	background: transparent !important;
+}
+
+body.yttweak-mini-player-mode .player-container-background,
+body.yttweak-mini-player-mode .player-container-background-image {
+	opacity: 0 !important;
+	visibility: hidden !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) {
+	position: fixed !important;
+	z-index: 2147483000 !important;
+	left: var(--yttweak-mini-player-left, auto) !important;
+	right: var(--yttweak-mini-player-right, auto) !important;
+	top: var(--yttweak-mini-player-top, auto) !important;
+	bottom: var(--yttweak-mini-player-bottom, auto) !important;
+	width: var(--yttweak-mini-player-width) !important;
+	height: auto !important;
+	aspect-ratio: var(--yttweak-mini-player-aspect-ratio, 16 / 9) !important;
+	background: #000 !important;
+	border-radius: 18px !important;
+	box-shadow:
+		0 24px 64px rgba(0, 0, 0, 0.36),
+		0 8px 24px rgba(0, 0, 0, 0.28);
+	overflow: hidden !important;
+	isolation: isolate;
+	opacity: 1 !important;
+	filter: none !important;
+	mix-blend-mode: normal !important;
+	will-change: top, right, bottom, left, width, opacity;
+	transition:
+		opacity 120ms ease-out,
+		box-shadow 120ms ease-out,
+		border-radius 120ms ease-out;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen)::before {
+	content: "";
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	background: #000;
+	pointer-events: none;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .html5-video-container,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-cued-thumbnail-overlay,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .html5-main-video,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) video.html5-main-video,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-iv-video-content,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-cued-thumbnail-overlay-image {
+	width: 100% !important;
+	height: 100% !important;
+	left: 0 !important;
+	top: 0 !important;
+	margin-left: 0 !important;
+	opacity: 1 !important;
+	background: #000 !important;
+	filter: none !important;
+	mix-blend-mode: normal !important;
+	visibility: visible !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .html5-video-player,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .html5-video-container {
+	height: 100% !important;
+	opacity: 1 !important;
+	background: #000 !important;
+	filter: none !important;
+	mix-blend-mode: normal !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-gradient-top,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-gradient-bottom,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-chrome-top,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-chrome-bottom,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-caption-window-container {
+	opacity: 1 !important;
+	filter: none !important;
+	mix-blend-mode: normal !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-caption-window-container > .caption-window {
+	left: var(--yttweak-mini-player-caption-window-left, 10%) !important;
+	width: var(--yttweak-mini-player-caption-window-width, 80%) !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .ytp-chrome-bottom {
+	width: calc(100% - 24px) !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-speed-buttons,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-volume-booster-strip,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-player-function-buttons,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-player-progress-tag {
+	display: none !important;
+}
+
+body.yttweak-mini-player-mode.yttweak-player-progress-enable #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-player-progress {
+	display: block !important;
+	opacity: 1 !important;
+	left: 0 !important;
+	right: 0 !important;
+	bottom: 0 !important;
+	width: 100% !important;
+	height: max(var(--yttweak-progress-height, 2px), 4px) !important;
+	z-index: 2197 !important;
+	border-radius: 0 !important;
+	background: rgba(255, 255, 255, 0.16) !important;
+	pointer-events: none !important;
+	box-shadow: 0 -1px 0 rgba(0, 0, 0, 0.18) inset;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-right-controls,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-right-controls,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .caption-window,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .caption-window,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .videowall-endscreen,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .videowall-endscreen,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-subtitles-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-subtitles-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-settings-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-settings-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-size-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-size-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-miniplayer-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-miniplayer-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-pip-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-pip-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-remote-button,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="cozy"] .ytp-remote-button {
+	display: none !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active[data-yttweak-mini-player-density="compact"] .ytp-left-controls .ytp-button:not(.ytp-play-button):not(.ytp-mute-button) {
+	display: none !important;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .video-ads,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-tooltip,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-preview,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-progress-bar-container,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-ce-element,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .iv-drawer {
+	display: none !important;
+}
+
+.yttweak-mini-player-placeholder {
+	display: block;
+	visibility: visible;
+	pointer-events: none;
+	max-width: 100%;
+	position: relative;
+	z-index: 0 !important;
+	box-sizing: border-box;
+	overflow: hidden;
+	background: #000 !important;
+	border-radius: 18px;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+	transition:
+		opacity 120ms ease-out,
+		background-color 120ms ease-out;
+}
+
+.yttweak-mini-player-close {
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	z-index: 2198;
+	display: none;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	border: 0;
+	border-radius: 999px;
+	background: rgba(14, 14, 16, 0.72);
+	backdrop-filter: blur(12px);
+	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+	color: white;
+	cursor: pointer;
+	opacity: 0.92;
+	transform: translateY(0);
+	transition:
+		opacity 160ms ease,
+		transform 160ms ease,
+		background-color 160ms ease;
+	appearance: none;
+	pointer-events: auto !important;
+
+	span,
+	svg {
+		width: 17px;
+		height: 17px;
+		display: block;
+		fill: currentColor;
+	}
+
+	&:hover {
+		background: rgba(24, 24, 27, 0.9);
+		opacity: 1;
+	}
+
+	&:focus-visible {
+		outline: 2px solid rgba(255, 255, 255, 0.8);
+		outline-offset: 2px;
+		opacity: 1;
+	}
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:hover .yttweak-mini-player-close,
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .yttweak-mini-player-close:focus-visible {
+	opacity: 1;
+}
+
+body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-mini-player-close {
+	display: inline-flex !important;
+}

--- a/src/inject/plugins/player-miniPlayer.scss
+++ b/src/inject/plugins/player-miniPlayer.scss
@@ -1,11 +1,21 @@
+body.yttweak-mini-player-mode {
+	overflow-anchor: none !important;
+}
+
 body.yttweak-mini-player-mode ytd-player,
 body.yttweak-mini-player-mode #player,
 body.yttweak-mini-player-mode #player-container,
 body.yttweak-mini-player-mode #full-bleed-container,
 body.yttweak-mini-player-mode #player-full-bleed-container {
 	overflow: visible !important;
-	z-index: auto !important;
 	background: transparent !important;
+}
+
+body.yttweak-mini-player-mode .yttweak-mini-player-stack-root {
+	position: relative !important;
+	overflow: visible !important;
+	overflow-anchor: none !important;
+	z-index: 2147483646 !important;
 }
 
 body.yttweak-mini-player-mode .player-container-background,
@@ -16,7 +26,7 @@ body.yttweak-mini-player-mode .player-container-background-image {
 
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) {
 	position: fixed !important;
-	z-index: 2147483000 !important;
+	z-index: 2147483647 !important;
 	left: var(--yttweak-mini-player-left, auto) !important;
 	right: var(--yttweak-mini-player-right, auto) !important;
 	top: var(--yttweak-mini-player-top, auto) !important;
@@ -149,23 +159,6 @@ body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-prog
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .ytp-ce-element,
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active .iv-drawer {
 	display: none !important;
-}
-
-.yttweak-mini-player-placeholder {
-	display: block;
-	visibility: visible;
-	pointer-events: none;
-	max-width: 100%;
-	position: relative;
-	z-index: 0 !important;
-	box-sizing: border-box;
-	overflow: hidden;
-	background: #000 !important;
-	border-radius: 18px;
-	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
-	transition:
-		opacity 120ms ease-out,
-		background-color 120ms ease-out;
 }
 
 .yttweak-mini-player-close {

--- a/src/inject/plugins/player-miniPlayer.scss
+++ b/src/inject/plugins/player-miniPlayer.scss
@@ -97,7 +97,6 @@ body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-
 }
 
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-speed-buttons,
-body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-volume-booster-strip,
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-player-function-buttons,
 body.yttweak-mini-player-mode #movie_player.yttweak-mini-player-active:not(.ytp-fullscreen) .yttweak-player-progress-tag {
 	display: none !important;

--- a/src/inject/plugins/player-miniPlayer.ts
+++ b/src/inject/plugins/player-miniPlayer.ts
@@ -1,0 +1,407 @@
+import config from "../config";
+import { videoPlayer } from "../mainWorld";
+
+import type { Plugin } from "../types";
+
+type MiniPlayerPosition = "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
+
+const DEFAULT_SIZE = "480x270";
+const DEFAULT_OFFSET = 16;
+const DEFAULT_TRIGGER = 48;
+const DEFAULT_ASPECT_RATIO = 16 / 9;
+const BODY_MODE_CLASS = "yttweak-mini-player-mode";
+const BODY_POSITION_PREFIX = "yttweak-mini-player-position-";
+
+let isMiniPlayerActive = false;
+let isMiniPlayerDismissed = false;
+let currentPlaceholder: HTMLDivElement | null = null;
+let currentPinnedPlayer: HTMLDivElement | null = null;
+let closeButton: HTMLButtonElement | null = null;
+let miniPlayerStyle: HTMLStyleElement | null = null;
+let updateFrame = 0;
+let globalListenersBound = false;
+let anchorBottomScrollY: number | null = null;
+let lastLayoutSignature = "";
+let originalPlayerParent: HTMLElement | null = null;
+let originalPlayerNextSibling: ChildNode | null = null;
+
+function createSvgElement(tagName: string) {
+	return document.createElementNS("http://www.w3.org/2000/svg", tagName);
+}
+
+function createCloseIcon() {
+	const svg = createSvgElement("svg");
+	svg.setAttribute("viewBox", "0 0 24 24");
+	svg.setAttribute("focusable", "false");
+
+	const path = createSvgElement("path");
+	path.setAttribute("d", "M6.4 5L12 10.6 17.6 5 19 6.4 13.4 12 19 17.6 17.6 19 12 13.4 6.4 19 5 17.6 10.6 12 5 6.4z");
+	svg.appendChild(path);
+
+	return svg;
+}
+
+function clampOffset(value: number) {
+	if (!Number.isFinite(value)) {
+		return DEFAULT_OFFSET;
+	}
+	return Math.max(0, Math.min(value, 96));
+}
+
+function clampTrigger(value: number) {
+	if (!Number.isFinite(value)) {
+		return DEFAULT_TRIGGER;
+	}
+	return Math.max(0, Math.min(value, 400));
+}
+
+function parseSizePreset(sizePreset: string) {
+	const [width, height] = sizePreset.split("x").map((value) => Number(value));
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+		return parseSizePreset(DEFAULT_SIZE);
+	}
+
+	return { width, height };
+}
+
+function getMiniPlayerAspectRatio() {
+	const video = videoPlayer.videoStream;
+	if (video?.videoWidth && video.videoHeight) {
+		return video.videoWidth / video.videoHeight;
+	}
+
+	const playerAspectRatio = videoPlayer.player?.getVideoAspectRatio?.();
+	if (typeof playerAspectRatio === "number" && Number.isFinite(playerAspectRatio) && playerAspectRatio > 0) {
+		return playerAspectRatio;
+	}
+
+	return DEFAULT_ASPECT_RATIO;
+}
+
+function getActivationScrollY() {
+	if (isMiniPlayerActive && anchorBottomScrollY !== null) {
+		return anchorBottomScrollY + clampTrigger(Number(config.get("player.miniPlayer.triggerOffset", DEFAULT_TRIGGER)));
+	}
+
+	const anchor = videoPlayer.player;
+	if (!anchor) {
+		return Number.POSITIVE_INFINITY;
+	}
+	const anchorRect = anchor.getBoundingClientRect();
+	return window.scrollY + anchorRect.bottom + clampTrigger(Number(config.get("player.miniPlayer.triggerOffset", DEFAULT_TRIGGER)));
+}
+
+function isWatchPage() {
+	const { pathname, searchParams } = new URL(window.location.href);
+	return pathname === "/watch" && searchParams.has("v");
+}
+
+function isEligibleToFloat() {
+	const player = videoPlayer.player;
+	const video = videoPlayer.videoStream;
+
+	if (!config.get("player.miniPlayer.enable")) {
+		return false;
+	}
+	if (!player || !video || !isWatchPage()) {
+		return false;
+	}
+	if (player.classList.contains("ytp-fullscreen") || document.pictureInPictureElement === video) {
+		return false;
+	}
+	if (video.ended || player.classList.contains("ended-mode")) {
+		return false;
+	}
+
+	return true;
+}
+
+function clearPlayerLayout(player: HTMLDivElement | null) {
+	if (!player) {
+		return;
+	}
+
+	player.classList.remove("yttweak-mini-player-active");
+	player.removeAttribute("data-yttweak-mini-player-density");
+	player.style.removeProperty("--yttweak-mini-player-width");
+	player.style.removeProperty("--yttweak-mini-player-height");
+	player.style.removeProperty("--yttweak-mini-player-left");
+	player.style.removeProperty("--yttweak-mini-player-right");
+	player.style.removeProperty("--yttweak-mini-player-top");
+	player.style.removeProperty("--yttweak-mini-player-bottom");
+}
+
+function clearBodyClasses() {
+	document.body.classList.remove(BODY_MODE_CLASS);
+	for (const position of ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"]) {
+		document.body.classList.remove(`${BODY_POSITION_PREFIX}${position}`);
+	}
+}
+
+function applyBodyClasses(position: MiniPlayerPosition) {
+	document.body.classList.add(BODY_MODE_CLASS);
+	for (const candidate of ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"] as const) {
+		document.body.classList.toggle(`${BODY_POSITION_PREFIX}${candidate}`, candidate === position);
+	}
+}
+
+function ensureMiniPlayerStyle() {
+	if (miniPlayerStyle) {
+		return miniPlayerStyle;
+	}
+
+	miniPlayerStyle = document.createElement("style");
+	miniPlayerStyle.id = "yttweak-mini-player-style";
+	document.head.appendChild(miniPlayerStyle);
+	return miniPlayerStyle;
+}
+
+function removePlaceholder() {
+	currentPlaceholder?.remove();
+	currentPlaceholder = null;
+}
+
+function getLayoutSignature() {
+	return [
+		window.innerWidth,
+		window.innerHeight,
+		config.get("player.miniPlayer.size", DEFAULT_SIZE),
+		config.get("player.miniPlayer.position", "bottom-right"),
+		config.get("player.miniPlayer.offset", DEFAULT_OFFSET),
+	].join(":");
+}
+
+function ensureCloseButton() {
+	const player = videoPlayer.player;
+	if (!player) {
+		return;
+	}
+
+	if (!closeButton) {
+		closeButton = document.createElement("button");
+		closeButton.type = "button";
+		closeButton.className = "yttweak-mini-player-close";
+		closeButton.setAttribute("aria-label", "Dismiss floating player");
+		closeButton.title = "Dismiss floating player";
+		const iconWrapper = document.createElement("span");
+		iconWrapper.setAttribute("aria-hidden", "true");
+		iconWrapper.appendChild(createCloseIcon());
+		closeButton.appendChild(iconWrapper);
+		closeButton.onclick = (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			isMiniPlayerDismissed = true;
+			deactivateMiniPlayer();
+		};
+	}
+
+	if (closeButton.parentElement !== player) {
+		closeButton.remove();
+		player.appendChild(closeButton);
+	}
+}
+
+function applyMiniPlayerLayout() {
+	const player = currentPinnedPlayer || videoPlayer.player;
+	if (!player) {
+		return;
+	}
+
+	const { width: maxWidth, height: maxHeight } = parseSizePreset(config.get("player.miniPlayer.size", DEFAULT_SIZE));
+	const offset = clampOffset(Number(config.get("player.miniPlayer.offset", DEFAULT_OFFSET)));
+	const position = config.get("player.miniPlayer.position", "bottom-right") as MiniPlayerPosition;
+	const aspectRatio = getMiniPlayerAspectRatio();
+
+	const boundedWidth = Math.max(260, Math.min(maxWidth, window.innerWidth - offset * 2));
+	const boundedHeight = Math.max(146, Math.min(maxHeight, window.innerHeight - offset * 2));
+
+	let width = boundedWidth;
+	let height = width / aspectRatio;
+
+	if (height > boundedHeight) {
+		height = boundedHeight;
+		width = height * aspectRatio;
+	}
+
+	width = Math.round(width);
+	height = Math.round(height);
+
+	let left = "auto";
+	let right = "auto";
+	let top = "auto";
+	let bottom = "auto";
+
+	if (position.startsWith("top")) {
+		const mastheadHeight = document.querySelector("#masthead-container")?.getBoundingClientRect().height || 0;
+		top = `${Math.round(offset + mastheadHeight)}px`;
+	} else {
+		bottom = `${offset}px`;
+	}
+
+	if (position.endsWith("left")) {
+		left = `${offset}px`;
+	} else if (position.endsWith("right")) {
+		right = `${offset}px`;
+	} else {
+		left = `${Math.max(offset, Math.round((window.innerWidth - width) / 2))}px`;
+	}
+
+	player.style.setProperty("--yttweak-mini-player-width", `${width}px`);
+	player.style.setProperty("--yttweak-mini-player-height", `${height}px`);
+	player.style.setProperty("--yttweak-mini-player-left", left);
+	player.style.setProperty("--yttweak-mini-player-right", right);
+	player.style.setProperty("--yttweak-mini-player-top", top);
+	player.style.setProperty("--yttweak-mini-player-bottom", bottom);
+	player.dataset.yttweakMiniPlayerDensity = width < 420 ? "compact" : width < 520 ? "cozy" : "full";
+
+	const style = ensureMiniPlayerStyle();
+	style.textContent = `
+		:root {
+			--yttweak-mini-player-width: ${width}px;
+			--yttweak-mini-player-height: ${height}px;
+			--yttweak-mini-player-aspect-ratio: ${aspectRatio};
+			--yttweak-mini-player-caption-window-left: ${Math.round(width * 0.1)}px;
+			--yttweak-mini-player-caption-window-width: ${Math.round(width * 0.8)}px;
+		}
+	`;
+	lastLayoutSignature = getLayoutSignature();
+}
+
+function activateMiniPlayer() {
+	const player = videoPlayer.player;
+	if (!player || isMiniPlayerActive || !player.parentElement) {
+		return;
+	}
+
+	const playerRect = player.getBoundingClientRect();
+	anchorBottomScrollY = window.scrollY + playerRect.bottom;
+	originalPlayerParent = player.parentElement;
+	originalPlayerNextSibling = player.nextSibling;
+	currentPlaceholder = document.createElement("div");
+	currentPlaceholder.className = "yttweak-mini-player-placeholder";
+	currentPlaceholder.style.width = `${Math.round(playerRect.width)}px`;
+	currentPlaceholder.style.height = `${Math.round(playerRect.height)}px`;
+	player.parentElement.insertBefore(currentPlaceholder, player);
+	currentPinnedPlayer = player;
+	document.body.appendChild(player);
+	player.classList.add("yttweak-mini-player-active");
+	applyBodyClasses(config.get("player.miniPlayer.position", "bottom-right") as MiniPlayerPosition);
+	ensureCloseButton();
+	applyMiniPlayerLayout();
+	isMiniPlayerActive = true;
+}
+
+function deactivateMiniPlayer() {
+	const player = currentPinnedPlayer || videoPlayer.player;
+	if (player && originalPlayerParent) {
+		if (currentPlaceholder?.parentElement === originalPlayerParent) {
+			originalPlayerParent.insertBefore(player, currentPlaceholder);
+			removePlaceholder();
+		} else if (originalPlayerNextSibling?.parentNode === originalPlayerParent) {
+			originalPlayerParent.insertBefore(player, originalPlayerNextSibling);
+		} else {
+			originalPlayerParent.appendChild(player);
+		}
+	}
+
+	clearPlayerLayout(player);
+	clearBodyClasses();
+	isMiniPlayerActive = false;
+	currentPinnedPlayer = null;
+	anchorBottomScrollY = null;
+	lastLayoutSignature = "";
+	originalPlayerParent = null;
+	originalPlayerNextSibling = null;
+}
+
+function updateMiniPlayerState() {
+	updateFrame = 0;
+
+	if (currentPinnedPlayer && currentPinnedPlayer !== videoPlayer.player) {
+		deactivateMiniPlayer();
+	}
+
+	const activationScrollY = getActivationScrollY();
+	if (isMiniPlayerDismissed && window.scrollY < activationScrollY - 120) {
+		isMiniPlayerDismissed = false;
+	}
+
+	if (!isEligibleToFloat()) {
+		deactivateMiniPlayer();
+		return;
+	}
+
+	if (window.scrollY >= activationScrollY && !isMiniPlayerDismissed) {
+		const position = config.get("player.miniPlayer.position", "bottom-right") as MiniPlayerPosition;
+		if (!isMiniPlayerActive) {
+			activateMiniPlayer();
+		} else if (lastLayoutSignature !== getLayoutSignature()) {
+			applyBodyClasses(position);
+			applyMiniPlayerLayout();
+		}
+		return;
+	}
+
+	deactivateMiniPlayer();
+}
+
+function scheduleMiniPlayerUpdate() {
+	if (updateFrame) {
+		return;
+	}
+
+	updateFrame = window.requestAnimationFrame(updateMiniPlayerState);
+}
+
+function bindGlobalListeners() {
+	if (globalListenersBound) {
+		return;
+	}
+
+	globalListenersBound = true;
+	window.addEventListener("scroll", scheduleMiniPlayerUpdate, { passive: true });
+	window.addEventListener("resize", scheduleMiniPlayerUpdate);
+	document.addEventListener("fullscreenchange", scheduleMiniPlayerUpdate);
+	document.addEventListener("visibilitychange", scheduleMiniPlayerUpdate);
+}
+
+function initPlayer() {
+	bindGlobalListeners();
+	isMiniPlayerDismissed = false;
+	ensureCloseButton();
+	videoPlayer.videoStream?.addEventListener("loadedmetadata", scheduleMiniPlayerUpdate);
+	videoPlayer.videoStream?.addEventListener("ended", scheduleMiniPlayerUpdate);
+	videoPlayer.videoStream?.addEventListener("play", scheduleMiniPlayerUpdate);
+	scheduleMiniPlayerUpdate();
+}
+
+export default {
+	"player.miniPlayer.enable": {
+		initPlayer,
+		enable() {
+			scheduleMiniPlayerUpdate();
+		},
+		disable() {
+			isMiniPlayerDismissed = false;
+			deactivateMiniPlayer();
+		},
+		configUpdate(oldConfig, newConfig) {
+			const shouldRefresh =
+				oldConfig["player.miniPlayer.enable"] !== newConfig["player.miniPlayer.enable"] ||
+				oldConfig["player.miniPlayer.size"] !== newConfig["player.miniPlayer.size"] ||
+				oldConfig["player.miniPlayer.position"] !== newConfig["player.miniPlayer.position"] ||
+				oldConfig["player.miniPlayer.offset"] !== newConfig["player.miniPlayer.offset"] ||
+				oldConfig["player.miniPlayer.triggerOffset"] !== newConfig["player.miniPlayer.triggerOffset"];
+
+			if (shouldRefresh) {
+				scheduleMiniPlayerUpdate();
+			}
+
+			return false;
+		},
+		videoSrcChange() {
+			isMiniPlayerDismissed = false;
+			scheduleMiniPlayerUpdate();
+		},
+	},
+} as Record<string, Plugin>;

--- a/src/inject/plugins/player-miniPlayer.ts
+++ b/src/inject/plugins/player-miniPlayer.ts
@@ -11,10 +11,23 @@ const DEFAULT_TRIGGER = 48;
 const DEFAULT_ASPECT_RATIO = 16 / 9;
 const BODY_MODE_CLASS = "yttweak-mini-player-mode";
 const BODY_POSITION_PREFIX = "yttweak-mini-player-position-";
+const STACK_ROOT_CLASS = "yttweak-mini-player-stack-root";
+const LAYOUT_STYLE_SELECTORS = [
+	".html5-video-player",
+	".html5-video-container",
+	".ytp-cued-thumbnail-overlay",
+	".html5-main-video",
+	"video.html5-main-video",
+	".ytp-iv-video-content",
+	".ytp-cued-thumbnail-overlay-image",
+	".ytp-chrome-bottom",
+	".ytp-caption-window-container",
+	".ytp-caption-window-container > .caption-window",
+] as const;
+const LAYOUT_STYLE_PROPERTIES = ["width", "height", "left", "right", "top", "bottom", "margin-left", "margin-top", "transform"] as const;
 
 let isMiniPlayerActive = false;
 let isMiniPlayerDismissed = false;
-let currentPlaceholder: HTMLDivElement | null = null;
 let currentPinnedPlayer: HTMLDivElement | null = null;
 let closeButton: HTMLButtonElement | null = null;
 let miniPlayerStyle: HTMLStyleElement | null = null;
@@ -22,8 +35,14 @@ let updateFrame = 0;
 let globalListenersBound = false;
 let anchorBottomScrollY: number | null = null;
 let lastLayoutSignature = "";
-let originalPlayerParent: HTMLElement | null = null;
-let originalPlayerNextSibling: ChildNode | null = null;
+let stackRootElements: HTMLElement[] = [];
+let layoutStyleSnapshots: LayoutStyleSnapshot[] = [];
+
+type LayoutStyleProperty = (typeof LAYOUT_STYLE_PROPERTIES)[number];
+type LayoutStyleSnapshot = {
+	element: HTMLElement;
+	properties: Record<LayoutStyleProperty, { value: string; priority: string }>;
+};
 
 function createSvgElement(tagName: string) {
 	return document.createElementNS("http://www.w3.org/2000/svg", tagName);
@@ -76,6 +95,43 @@ function getMiniPlayerAspectRatio() {
 	}
 
 	return DEFAULT_ASPECT_RATIO;
+}
+
+function getViewportAnchorElement() {
+	const points: Array<[number, number]> = [
+		[window.innerWidth / 2, window.innerHeight * 0.35],
+		[window.innerWidth / 2, window.innerHeight * 0.5],
+		[window.innerWidth / 2, window.innerHeight * 0.7],
+		[window.innerWidth * 0.25, window.innerHeight * 0.5],
+		[window.innerWidth * 0.75, window.innerHeight * 0.5],
+	];
+
+	for (const [x, y] of points) {
+		const element = document.elementFromPoint(Math.round(x), Math.round(y));
+		if (element instanceof HTMLElement && !element.closest("#movie_player")) {
+			return element;
+		}
+	}
+
+	return document.querySelector<HTMLElement>("ytd-watch-flexy #columns, ytd-comments, #secondary, #below");
+}
+
+function preserveViewportPosition(callback: () => void) {
+	const anchorElement = getViewportAnchorElement();
+	const anchorTop = anchorElement?.getBoundingClientRect().top ?? null;
+	const scrollLeft = window.scrollX;
+	const scrollTop = window.scrollY;
+
+	callback();
+	void document.documentElement.offsetHeight;
+
+	if (anchorElement?.isConnected && anchorTop !== null) {
+		const anchorDelta = anchorElement.getBoundingClientRect().top - anchorTop;
+		window.scrollTo(scrollLeft, window.scrollY + anchorDelta);
+		return;
+	}
+
+	window.scrollTo(scrollLeft, scrollTop);
 }
 
 function getActivationScrollY() {
@@ -156,9 +212,79 @@ function ensureMiniPlayerStyle() {
 	return miniPlayerStyle;
 }
 
-function removePlaceholder() {
-	currentPlaceholder?.remove();
-	currentPlaceholder = null;
+function clearStackRoots() {
+	for (const element of stackRootElements) {
+		element.classList.remove(STACK_ROOT_CLASS);
+	}
+	stackRootElements = [];
+}
+
+function applyStackRoots(player: HTMLElement) {
+	clearStackRoots();
+
+	let element = player.parentElement;
+	while (element && element !== document.body && element !== document.documentElement) {
+		element.classList.add(STACK_ROOT_CLASS);
+		stackRootElements.push(element);
+		element = element.parentElement;
+	}
+}
+
+function captureLayoutStyles(player: HTMLElement) {
+	layoutStyleSnapshots = [];
+
+	const elements = new Set<HTMLElement>([player]);
+	for (const selector of LAYOUT_STYLE_SELECTORS) {
+		for (const element of player.querySelectorAll<HTMLElement>(selector)) {
+			elements.add(element);
+		}
+	}
+
+	for (const element of elements) {
+		const properties = {} as LayoutStyleSnapshot["properties"];
+		for (const property of LAYOUT_STYLE_PROPERTIES) {
+			properties[property] = {
+				value: element.style.getPropertyValue(property),
+				priority: element.style.getPropertyPriority(property),
+			};
+		}
+		layoutStyleSnapshots.push({ element, properties });
+	}
+}
+
+function restoreLayoutStyles() {
+	for (const snapshot of layoutStyleSnapshots) {
+		for (const property of LAYOUT_STYLE_PROPERTIES) {
+			const { value, priority } = snapshot.properties[property];
+			if (value) {
+				snapshot.element.style.setProperty(property, value, priority);
+			} else {
+				snapshot.element.style.removeProperty(property);
+			}
+		}
+	}
+	layoutStyleSnapshots = [];
+}
+
+function notifyNativePlayerResize(player: HTMLElement | null) {
+	if (!player || player.classList.contains("yttweak-mini-player-active")) {
+		return;
+	}
+
+	preserveViewportPosition(() => {
+		window.dispatchEvent(new Event("resize"));
+		player.dispatchEvent(new Event("resize"));
+		videoPlayer.videoStream?.dispatchEvent(new Event("resize"));
+		player.closest<HTMLElement>("ytd-player")?.dispatchEvent(new Event("resize"));
+	});
+}
+
+function scheduleNativeLayoutRefresh(player: HTMLElement | null) {
+	window.requestAnimationFrame(() => {
+		notifyNativePlayerResize(player);
+		window.requestAnimationFrame(() => notifyNativePlayerResize(player));
+		window.setTimeout(() => notifyNativePlayerResize(player), 120);
+	});
 }
 
 function getLayoutSignature() {
@@ -275,43 +401,38 @@ function activateMiniPlayer() {
 
 	const playerRect = player.getBoundingClientRect();
 	anchorBottomScrollY = window.scrollY + playerRect.bottom;
-	originalPlayerParent = player.parentElement;
-	originalPlayerNextSibling = player.nextSibling;
-	currentPlaceholder = document.createElement("div");
-	currentPlaceholder.className = "yttweak-mini-player-placeholder";
-	currentPlaceholder.style.width = `${Math.round(playerRect.width)}px`;
-	currentPlaceholder.style.height = `${Math.round(playerRect.height)}px`;
-	player.parentElement.insertBefore(currentPlaceholder, player);
+	captureLayoutStyles(player);
 	currentPinnedPlayer = player;
-	document.body.appendChild(player);
-	player.classList.add("yttweak-mini-player-active");
-	applyBodyClasses(config.get("player.miniPlayer.position", "bottom-right") as MiniPlayerPosition);
 	ensureCloseButton();
 	applyMiniPlayerLayout();
+
+	preserveViewportPosition(() => {
+		applyBodyClasses(config.get("player.miniPlayer.position", "bottom-right") as MiniPlayerPosition);
+		applyStackRoots(player);
+		player.classList.add("yttweak-mini-player-active");
+	});
 	isMiniPlayerActive = true;
 }
 
 function deactivateMiniPlayer() {
 	const player = currentPinnedPlayer || videoPlayer.player;
-	if (player && originalPlayerParent) {
-		if (currentPlaceholder?.parentElement === originalPlayerParent) {
-			originalPlayerParent.insertBefore(player, currentPlaceholder);
-			removePlaceholder();
-		} else if (originalPlayerNextSibling?.parentNode === originalPlayerParent) {
-			originalPlayerParent.insertBefore(player, originalPlayerNextSibling);
-		} else {
-			originalPlayerParent.appendChild(player);
-		}
+	const wasMiniPlayerActive = isMiniPlayerActive || currentPinnedPlayer !== null || layoutStyleSnapshots.length > 0;
+
+	if (!wasMiniPlayerActive) {
+		return;
 	}
 
-	clearPlayerLayout(player);
+	preserveViewportPosition(() => {
+		clearStackRoots();
+		clearPlayerLayout(player);
+		restoreLayoutStyles();
+	});
 	clearBodyClasses();
+	scheduleNativeLayoutRefresh(player);
 	isMiniPlayerActive = false;
 	currentPinnedPlayer = null;
 	anchorBottomScrollY = null;
 	lastLayoutSignature = "";
-	originalPlayerParent = null;
-	originalPlayerNextSibling = null;
 }
 
 function updateMiniPlayerState() {

--- a/src/inject/plugins/player-speedButton.ts
+++ b/src/inject/plugins/player-speedButton.ts
@@ -9,6 +9,7 @@ import memory from "@/memory";
 const logger = createLogger("player-speedButton");
 
 const speedButtons: HTMLSpanElement[] = [];
+let speedButtonDiv: HTMLDivElement | null = null;
 
 async function setMemorySpeed() {
 	let speed;
@@ -53,6 +54,17 @@ async function setMemorySpeed() {
 	});
 }
 
+function mountSpeedButtonStrip() {
+	if (!videoPlayer.controls || !speedButtonDiv) {
+		return;
+	}
+
+	const rightControls = videoPlayer.controls.querySelector(".ytp-right-controls");
+	if (speedButtonDiv.parentElement !== videoPlayer.controls) {
+		videoPlayer.controls.insertBefore(speedButtonDiv, rightControls || null);
+	}
+}
+
 export default {
 	"player.ui.enableSpeedButtons": {
 		enable() {
@@ -62,40 +74,39 @@ export default {
 			document.body.removeAttribute("yttweak-enable-speed-button");
 		},
 		initPlayer() {
-			const speedButtonDiv = document.createElement("div");
-			speedButtonDiv.className = "yttweak-speed-buttons";
-			for (let speed of [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 5, 10]) {
-				const speedButton = document.createElement("span");
-				speedButton.className = `yttweak-speed-button`;
-				speedButton.setAttribute("speed", `${speed}`);
-				speedButton.onclick = async () => {
-					videoPlayer.player?.setPlaybackRate(speed);
-					if (videoPlayer.videoStream) videoPlayer.videoStream.playbackRate = speed;
-					logger.info("Set playback rate:", speed);
+			if (!speedButtonDiv) {
+				speedButtonDiv = document.createElement("div");
+				speedButtonDiv.className = "yttweak-speed-buttons";
+				for (let speed of [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 5, 10]) {
+					const speedButton = document.createElement("span");
+					speedButton.className = `yttweak-speed-button`;
+					speedButton.setAttribute("speed", `${speed}`);
+					speedButton.onclick = async () => {
+						videoPlayer.player?.setPlaybackRate(speed);
+						if (videoPlayer.videoStream) videoPlayer.videoStream.playbackRate = speed;
+						logger.info("Set playback rate:", speed);
 
-					if (config.get("player.settings.saveSpeed")) {
-						await memory.set("", "s", speed);
-					}
-					if (config.get("player.settings.saveSpeedByChannel")) {
-						const channelId = getChannelId();
-						if (channelId) {
-							await memory.set(channelId, "s", speed);
+						if (config.get("player.settings.saveSpeed")) {
+							await memory.set("", "s", speed);
 						}
-					}
+						if (config.get("player.settings.saveSpeedByChannel")) {
+							const channelId = getChannelId();
+							if (channelId) {
+								await memory.set(channelId, "s", speed);
+							}
+						}
 
-					speedButtons.forEach((v) => {
-						v.classList.remove("yttweak-speed-button-active");
-					});
-					speedButton.classList.add("yttweak-speed-button-active");
-				};
-				speedButtons.push(speedButton);
-				speedButtonDiv.appendChild(speedButton);
-			}
-			if (videoPlayer.controls) {
-				const left = videoPlayer.controls.querySelector(".ytp-left-controls")?.nextSibling;
-				if (left) videoPlayer.controls.insertBefore(speedButtonDiv, left);
+						speedButtons.forEach((v) => {
+							v.classList.remove("yttweak-speed-button-active");
+						});
+						speedButton.classList.add("yttweak-speed-button-active");
+					};
+					speedButtons.push(speedButton);
+					speedButtonDiv.appendChild(speedButton);
+				}
 			}
 
+			mountSpeedButtonStrip();
 			setMemorySpeed();
 		},
 		videoSrcChange(oldValue, newValue) {

--- a/src/inject/plugins/player-volumeBooster.scss
+++ b/src/inject/plugins/player-volumeBooster.scss
@@ -1,96 +1,15 @@
-.yttweak-volume-booster-strip {
-	display: none;
-	margin-top: var(--yt-delhi-pill-top-height, 12px);
-	margin-right: 10px;
-	height: var(--yt-delhi-pill-height, 48px);
-	border-radius: 28px;
-	backdrop-filter: var(--yt-frosted-glass-backdrop-filter-override, blur(16px));
-	background: var(--yt-spec-overlay-background-medium-light, rgba(0, 0, 0, 0.3));
-	padding: 4px;
-	box-sizing: border-box;
-	align-items: center;
-}
-
-.yttweak-volume-booster-strip.yttweak-volume-booster-visible {
-	display: flex !important;
-}
-
-.yttweak-volume-booster-button {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
-	width: 48px;
-	padding: 0;
-	border: 0;
-	border-radius: 20px;
-	background: transparent;
-	color: white;
-	cursor: pointer;
-	font: inherit;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
-	transition:
-		background-color 180ms ease,
-		color 180ms ease,
-		transform 180ms ease,
-		box-shadow 180ms ease,
-		border-color 180ms ease;
-	position: relative;
-	border: 1px solid transparent;
-
-	&:hover {
-		background: rgba(white, 0.12);
+.yttweak-function-button-volume-booster {
+	&::before {
+		background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.5 10h3L10 6.5v11L6.5 14h-3z' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M14 17v-7h5' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M16.5 7.5 19 10l-2.5 2.5' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	}
 
-	&::after {
-		content: "";
-		position: absolute;
-		inset: 4px;
-		border-radius: 20px;
-		pointer-events: none;
-		transition: background-color 180ms ease;
-	}
-
-	&:hover::after {
-		background: rgba(255, 255, 255, 0.06);
-	}
-
-	&:focus-visible {
-		outline: 2px solid rgba(255, 255, 255, 0.75);
-		outline-offset: 2px;
-	}
-
-	&.yttweak-volume-booster-active {
-		background: rgba(255, 255, 255, 0.12);
-		border-color: rgba(255, 255, 255, 0.42);
-		box-shadow:
-			inset 0 0 0 1px rgba(255, 255, 255, 0.1),
-			0 0 0 1px rgba(0, 0, 0, 0.12);
+	&.yttweak-volume-booster-active::after {
+		color: red;
 	}
 }
 
-.yttweak-volume-booster-icon {
-	width: 22px;
-	height: 22px;
-	flex: 0 0 auto;
-	opacity: 0.96;
-
-	svg {
-		display: block;
-		width: 100%;
-		height: 100%;
+body.yttweak-player-enable-volume-booster {
+	.yttweak-player-function-buttons span.yttweak-function-button-volume-booster {
+		display: flex;
 	}
-
-	.yttweak-volume-booster-outline {
-		fill: none;
-		stroke: currentColor;
-		stroke-width: 2;
-		stroke-linecap: round;
-		stroke-linejoin: round;
-		vector-effect: non-scaling-stroke;
-	}
-}
-
-.yttweak-volume-booster-button.yttweak-volume-booster-active .yttweak-volume-booster-icon {
-	opacity: 1;
 }

--- a/src/inject/plugins/player-volumeBooster.scss
+++ b/src/inject/plugins/player-volumeBooster.scss
@@ -1,0 +1,96 @@
+.yttweak-volume-booster-strip {
+	display: none;
+	margin-top: var(--yt-delhi-pill-top-height, 12px);
+	margin-right: 10px;
+	height: var(--yt-delhi-pill-height, 48px);
+	border-radius: 28px;
+	backdrop-filter: var(--yt-frosted-glass-backdrop-filter-override, blur(16px));
+	background: var(--yt-spec-overlay-background-medium-light, rgba(0, 0, 0, 0.3));
+	padding: 4px;
+	box-sizing: border-box;
+	align-items: center;
+}
+
+.yttweak-volume-booster-strip.yttweak-volume-booster-visible {
+	display: flex !important;
+}
+
+.yttweak-volume-booster-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	width: 48px;
+	padding: 0;
+	border: 0;
+	border-radius: 20px;
+	background: transparent;
+	color: white;
+	cursor: pointer;
+	font: inherit;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+	transition:
+		background-color 180ms ease,
+		color 180ms ease,
+		transform 180ms ease,
+		box-shadow 180ms ease,
+		border-color 180ms ease;
+	position: relative;
+	border: 1px solid transparent;
+
+	&:hover {
+		background: rgba(white, 0.12);
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 4px;
+		border-radius: 20px;
+		pointer-events: none;
+		transition: background-color 180ms ease;
+	}
+
+	&:hover::after {
+		background: rgba(255, 255, 255, 0.06);
+	}
+
+	&:focus-visible {
+		outline: 2px solid rgba(255, 255, 255, 0.75);
+		outline-offset: 2px;
+	}
+
+	&.yttweak-volume-booster-active {
+		background: rgba(255, 255, 255, 0.12);
+		border-color: rgba(255, 255, 255, 0.42);
+		box-shadow:
+			inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+			0 0 0 1px rgba(0, 0, 0, 0.12);
+	}
+}
+
+.yttweak-volume-booster-icon {
+	width: 22px;
+	height: 22px;
+	flex: 0 0 auto;
+	opacity: 0.96;
+
+	svg {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.yttweak-volume-booster-outline {
+		fill: none;
+		stroke: currentColor;
+		stroke-width: 2;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+		vector-effect: non-scaling-stroke;
+	}
+}
+
+.yttweak-volume-booster-button.yttweak-volume-booster-active .yttweak-volume-booster-icon {
+	opacity: 1;
+}

--- a/src/inject/plugins/player-volumeBooster.scss
+++ b/src/inject/plugins/player-volumeBooster.scss
@@ -1,6 +1,6 @@
 .yttweak-function-button-volume-booster {
 	&::before {
-		background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.5 10h3L10 6.5v11L6.5 14h-3z' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M14 17v-7h5' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M16.5 7.5 19 10l-2.5 2.5' stroke='%23fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+		background-image: url("data:image/svg+xml,%3Csvg viewBox='36 18 220 220' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='%23fff' stroke-width='18' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M42 96c0-5.5 4.5-10 10-10h32l55-44c7.2-5.8 18 .7 18 8.5v155c0 9.2-10.8 14.3-18 8.5l-55-44H52c-5.5 0-10-4.5-10-10V96Z'/%3E%3Cpath d='M222 95v56M196 123h52'/%3E%3C/g%3E%3C/svg%3E");
 	}
 
 	&.yttweak-volume-booster-active::after {

--- a/src/inject/plugins/player-volumeBooster.ts
+++ b/src/inject/plugins/player-volumeBooster.ts
@@ -1,10 +1,16 @@
 import config from "../config";
 import { videoPlayer } from "../mainWorld";
 import { createLogger } from "../../logger";
+import { createBox, updateFuncBtnStatus, yttBtnBox } from "./player-function-buttons";
 
 import type { Plugin } from "../types";
 
 const logger = createLogger("player-volumeBooster");
+const DEFAULT_MULTIPLIER = 2;
+const MIN_MULTIPLIER = 1.25;
+const MAX_MULTIPLIER = 5;
+const MULTIPLIER_STEP = 0.25;
+const BODY_CONTROL_CLASS = "yttweak-player-enable-volume-booster";
 
 type AudioContextConstructor = typeof AudioContext;
 type AudioChain = {
@@ -20,34 +26,16 @@ let activeAudioChain: AudioChain | null = null;
 let playerBoundForBooster: HTMLVideoElement | null = null;
 let resumeListenersBound = false;
 
-let boosterStrip: HTMLDivElement | null = null;
-let boosterButton: HTMLButtonElement | null = null;
-
-function createSvgElement(tagName: string) {
-	return document.createElementNS("http://www.w3.org/2000/svg", tagName);
-}
-
-function createBoosterIcon() {
-	const svg = createSvgElement("svg");
-	svg.setAttribute("viewBox", "0 0 24 24");
-	svg.setAttribute("focusable", "false");
-
-	const outline = createSvgElement("path");
-	outline.setAttribute("class", "yttweak-volume-booster-outline");
-	outline.setAttribute(
-		"d",
-		"M15 8a5 5 0 0 1 0 8m2.7-11a9 9 0 0 1 0 14M6 15H4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h2l3.5-4.5A.8.8 0 0 1 11 5v14a.8.8 0 0 1-1.5.5z",
-	);
-
-	svg.append(outline);
-	return svg;
-}
+let boosterButton: HTMLSpanElement | null = null;
+let boosterControlVisible = false;
 
 function clampMultiplier(value: number) {
-	if (!Number.isFinite(value) || value < 1) {
-		return 1;
+	if (!Number.isFinite(value)) {
+		return DEFAULT_MULTIPLIER;
 	}
-	return Math.min(value, 5);
+
+	const steppedValue = Math.round(value / MULTIPLIER_STEP) * MULTIPLIER_STEP;
+	return Math.min(Math.max(steppedValue, MIN_MULTIPLIER), MAX_MULTIPLIER);
 }
 
 function formatMultiplier(value: number) {
@@ -57,17 +45,32 @@ function formatMultiplier(value: number) {
 		.replace(/(\.\d)0$/, "$1");
 }
 
+function getConfiguredMultiplier() {
+	return clampMultiplier(Number(config.get("player.settings.volumeBoosterMultiplier", DEFAULT_MULTIPLIER)));
+}
+
+function setBoosterControlVisible(visible: boolean) {
+	document.body.classList.toggle(BODY_CONTROL_CLASS, visible);
+
+	if (boosterControlVisible === visible) {
+		return;
+	}
+
+	boosterControlVisible = visible;
+	updateFuncBtnStatus(visible);
+}
+
 function updateButtonState() {
 	if (!boosterButton) {
 		return;
 	}
 
 	const isEnabled = config.get("player.settings.volumeBooster");
-	const multiplier = clampMultiplier(Number(config.get("player.settings.volumeBoosterMultiplier")));
+	const multiplier = getConfiguredMultiplier();
 	const buttonText = `Volume booster ${isEnabled ? "on" : "off"} (${formatMultiplier(multiplier)}x)`;
 
-	boosterStrip?.classList.toggle("yttweak-volume-booster-visible", config.get("player.ui.enableVolumeBooster"));
 	boosterButton.classList.toggle("yttweak-volume-booster-active", isEnabled);
+	boosterButton.setAttribute("text", `${formatMultiplier(multiplier)}x`);
 	boosterButton.setAttribute("aria-pressed", String(isEnabled));
 	boosterButton.title = buttonText;
 }
@@ -214,8 +217,14 @@ async function syncBoosterState() {
 		return;
 	}
 
-	const multiplier = clampMultiplier(Number(config.get("player.settings.volumeBoosterMultiplier")));
+	const multiplier = getConfiguredMultiplier();
 	chain.gain.gain.setValueAtTime(multiplier, chain.context.currentTime);
+}
+
+function setBoosterMultiplier(multiplier: number) {
+	config.set("player.settings.volumeBoosterMultiplier", clampMultiplier(multiplier));
+	updateButtonState();
+	void syncBoosterState();
 }
 
 async function setBoosterEnabled(nextState: boolean) {
@@ -232,19 +241,44 @@ async function setBoosterEnabled(nextState: boolean) {
 	await syncBoosterState();
 }
 
-function mountBoosterStrip() {
-	const controls = videoPlayer.controls;
-	if (!controls) {
+function stepBoosterMultiplier(direction: 1 | -1) {
+	const isEnabled = config.get("player.settings.volumeBooster");
+
+	if (direction > 0) {
+		if (!isEnabled) {
+			config.set("player.settings.volumeBoosterMultiplier", MIN_MULTIPLIER);
+			void setBoosterEnabled(true);
+			return;
+		}
+
+		setBoosterMultiplier(getConfiguredMultiplier() + MULTIPLIER_STEP);
 		return;
 	}
 
-	if (!boosterStrip) {
-		boosterStrip = document.createElement("div");
-		boosterStrip.className = "yttweak-volume-booster-strip";
+	if (!isEnabled) {
+		return;
+	}
 
-		boosterButton = document.createElement("button");
-		boosterButton.type = "button";
-		boosterButton.className = "yttweak-volume-booster-button";
+	const currentMultiplier = getConfiguredMultiplier();
+	if (currentMultiplier <= MIN_MULTIPLIER) {
+		void setBoosterEnabled(false);
+		return;
+	}
+
+	setBoosterMultiplier(currentMultiplier - MULTIPLIER_STEP);
+}
+
+function mountBoosterButton() {
+	createBox();
+
+	if (!yttBtnBox) {
+		return;
+	}
+
+	if (!boosterButton) {
+		boosterButton = document.createElement("span");
+		boosterButton.className = "yttweak-function-button-volume-booster";
+		boosterButton.setAttribute("role", "button");
 		boosterButton.setAttribute("aria-label", "Toggle volume booster");
 		boosterButton.onclick = (event) => {
 			event.preventDefault();
@@ -253,23 +287,18 @@ function mountBoosterStrip() {
 			const nextState = !config.get("player.settings.volumeBooster");
 			void setBoosterEnabled(nextState);
 		};
-
-		const icon = document.createElement("span");
-		icon.className = "yttweak-volume-booster-icon";
-		icon.setAttribute("aria-hidden", "true");
-		icon.appendChild(createBoosterIcon());
-		boosterButton.appendChild(icon);
-		boosterStrip.appendChild(boosterButton);
+		boosterButton.onwheel = (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (!event.deltaY) {
+				return;
+			}
+			stepBoosterMultiplier(event.deltaY < 0 ? 1 : -1);
+		};
 	}
 
-	const rightControls = controls.querySelector(".ytp-right-controls");
-	const speedStrip = controls.querySelector(".yttweak-speed-buttons");
-	const insertBeforeNode = speedStrip?.nextSibling || rightControls || null;
-
-	if (boosterStrip.parentElement !== controls) {
-		controls.insertBefore(boosterStrip, insertBeforeNode);
-	} else if (speedStrip && boosterStrip.previousSibling !== speedStrip) {
-		controls.insertBefore(boosterStrip, speedStrip.nextSibling || rightControls || null);
+	if (boosterButton.parentElement !== yttBtnBox) {
+		yttBtnBox.appendChild(boosterButton);
 	}
 
 	updateButtonState();
@@ -283,7 +312,7 @@ function initPlayer() {
 		playerBoundForBooster = null;
 	}
 
-	mountBoosterStrip();
+	mountBoosterButton();
 	videoPlayer.videoStream?.addEventListener("play", syncBoosterState);
 	videoPlayer.videoStream?.addEventListener("loadedmetadata", syncBoosterState);
 	videoPlayer.videoStream?.addEventListener("ended", syncBoosterState);
@@ -291,7 +320,8 @@ function initPlayer() {
 }
 
 function refreshVolumeBoosterUi() {
-	mountBoosterStrip();
+	setBoosterControlVisible(config.get("player.ui.enableVolumeBooster"));
+	mountBoosterButton();
 	void syncBoosterState();
 }
 
@@ -299,10 +329,12 @@ export default {
 	"player.ui.enableVolumeBooster": {
 		initPlayer,
 		enable() {
-			mountBoosterStrip();
+			setBoosterControlVisible(true);
+			mountBoosterButton();
 			updateButtonState();
 		},
 		disable() {
+			setBoosterControlVisible(false);
 			updateButtonState();
 		},
 		configUpdate(oldConfig, newConfig) {

--- a/src/inject/plugins/player-volumeBooster.ts
+++ b/src/inject/plugins/player-volumeBooster.ts
@@ -51,7 +51,10 @@ function clampMultiplier(value: number) {
 }
 
 function formatMultiplier(value: number) {
-	return clampMultiplier(value).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+	return clampMultiplier(value)
+		.toFixed(2)
+		.replace(/\.00$/, "")
+		.replace(/(\.\d)0$/, "$1");
 }
 
 function updateButtonState() {
@@ -100,6 +103,48 @@ function getAudioContextConstructor(): AudioContextConstructor | null {
 	return window.AudioContext || (window as typeof window & { webkitAudioContext?: AudioContextConstructor }).webkitAudioContext || null;
 }
 
+function resetAudioChainGain(chain: AudioChain) {
+	try {
+		chain.gain.gain.setValueAtTime(1, chain.context.currentTime);
+	} catch (error) {
+		logger.warn("Failed to reset volume booster gain:", error);
+	}
+}
+
+function disposeAudioChain(chain: AudioChain | null) {
+	if (!chain) {
+		return;
+	}
+
+	resetAudioChainGain(chain);
+	audioChains.delete(chain.video);
+
+	if (activeAudioChain === chain) {
+		activeAudioChain = null;
+	}
+	if (playerBoundForBooster === chain.video) {
+		playerBoundForBooster = null;
+	}
+
+	try {
+		chain.source.disconnect();
+	} catch (error) {
+		logger.warn("Failed to disconnect volume booster source:", error);
+	}
+
+	try {
+		chain.gain.disconnect();
+	} catch (error) {
+		logger.warn("Failed to disconnect volume booster gain:", error);
+	}
+
+	if (chain.context.state !== "closed") {
+		chain.context.close().catch((error) => {
+			logger.warn("Failed to close volume booster audio context:", error);
+		});
+	}
+}
+
 async function ensureAudioChain() {
 	const video = videoPlayer.videoStream;
 	if (!video) {
@@ -114,7 +159,7 @@ async function ensureAudioChain() {
 		return activeAudioChain;
 	}
 
-	activeAudioChain?.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+	disposeAudioChain(activeAudioChain);
 
 	const cachedChain = audioChains.get(video);
 	if (cachedChain) {
@@ -159,7 +204,7 @@ async function syncBoosterState() {
 
 	if (!config.get("player.settings.volumeBooster")) {
 		if (activeAudioChain) {
-			activeAudioChain.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+			resetAudioChainGain(activeAudioChain);
 		}
 		return;
 	}
@@ -179,7 +224,7 @@ async function setBoosterEnabled(nextState: boolean) {
 
 	if (!nextState) {
 		if (activeAudioChain) {
-			activeAudioChain.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+			resetAudioChainGain(activeAudioChain);
 		}
 		return;
 	}
@@ -231,9 +276,11 @@ function mountBoosterStrip() {
 }
 
 function initPlayer() {
-	if (playerBoundForBooster && playerBoundForBooster !== videoPlayer.videoStream) {
-		activeAudioChain?.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
-		activeAudioChain = null;
+	const currentVideo = videoPlayer.videoStream;
+	if (activeAudioChain && activeAudioChain.video !== currentVideo) {
+		disposeAudioChain(activeAudioChain);
+	} else if (playerBoundForBooster && playerBoundForBooster !== currentVideo) {
+		playerBoundForBooster = null;
 	}
 
 	mountBoosterStrip();

--- a/src/inject/plugins/player-volumeBooster.ts
+++ b/src/inject/plugins/player-volumeBooster.ts
@@ -1,0 +1,299 @@
+import config from "../config";
+import { videoPlayer } from "../mainWorld";
+import { createLogger } from "../../logger";
+
+import type { Plugin } from "../types";
+
+const logger = createLogger("player-volumeBooster");
+
+type AudioContextConstructor = typeof AudioContext;
+type AudioChain = {
+	context: AudioContext;
+	source: MediaElementAudioSourceNode;
+	gain: GainNode;
+	video: HTMLVideoElement;
+};
+
+const audioChains = new WeakMap<HTMLVideoElement, AudioChain>();
+
+let activeAudioChain: AudioChain | null = null;
+let playerBoundForBooster: HTMLVideoElement | null = null;
+let resumeListenersBound = false;
+
+let boosterStrip: HTMLDivElement | null = null;
+let boosterButton: HTMLButtonElement | null = null;
+
+function createSvgElement(tagName: string) {
+	return document.createElementNS("http://www.w3.org/2000/svg", tagName);
+}
+
+function createBoosterIcon() {
+	const svg = createSvgElement("svg");
+	svg.setAttribute("viewBox", "0 0 24 24");
+	svg.setAttribute("focusable", "false");
+
+	const outline = createSvgElement("path");
+	outline.setAttribute("class", "yttweak-volume-booster-outline");
+	outline.setAttribute(
+		"d",
+		"M15 8a5 5 0 0 1 0 8m2.7-11a9 9 0 0 1 0 14M6 15H4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h2l3.5-4.5A.8.8 0 0 1 11 5v14a.8.8 0 0 1-1.5.5z",
+	);
+
+	svg.append(outline);
+	return svg;
+}
+
+function clampMultiplier(value: number) {
+	if (!Number.isFinite(value) || value < 1) {
+		return 1;
+	}
+	return Math.min(value, 5);
+}
+
+function formatMultiplier(value: number) {
+	return clampMultiplier(value).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+}
+
+function updateButtonState() {
+	if (!boosterButton) {
+		return;
+	}
+
+	const isEnabled = config.get("player.settings.volumeBooster");
+	const multiplier = clampMultiplier(Number(config.get("player.settings.volumeBoosterMultiplier")));
+	const buttonText = `Volume booster ${isEnabled ? "on" : "off"} (${formatMultiplier(multiplier)}x)`;
+
+	boosterStrip?.classList.toggle("yttweak-volume-booster-visible", config.get("player.ui.enableVolumeBooster"));
+	boosterButton.classList.toggle("yttweak-volume-booster-active", isEnabled);
+	boosterButton.setAttribute("aria-pressed", String(isEnabled));
+	boosterButton.title = buttonText;
+}
+
+async function resumeActiveContext() {
+	if (!activeAudioChain || activeAudioChain.context.state !== "suspended") {
+		return;
+	}
+
+	try {
+		await activeAudioChain.context.resume();
+	} catch (error) {
+		logger.warn("Failed to resume volume booster audio context:", error);
+	}
+}
+
+function bindResumeListeners() {
+	if (resumeListenersBound) {
+		return;
+	}
+
+	resumeListenersBound = true;
+	const resume = () => {
+		void resumeActiveContext();
+	};
+
+	window.addEventListener("pointerdown", resume, true);
+	window.addEventListener("keydown", resume, true);
+	window.addEventListener("touchstart", resume, true);
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | null {
+	return window.AudioContext || (window as typeof window & { webkitAudioContext?: AudioContextConstructor }).webkitAudioContext || null;
+}
+
+async function ensureAudioChain() {
+	const video = videoPlayer.videoStream;
+	if (!video) {
+		return null;
+	}
+
+	playerBoundForBooster = video;
+	bindResumeListeners();
+
+	if (activeAudioChain?.video === video) {
+		await resumeActiveContext();
+		return activeAudioChain;
+	}
+
+	activeAudioChain?.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+
+	const cachedChain = audioChains.get(video);
+	if (cachedChain) {
+		activeAudioChain = cachedChain;
+		await resumeActiveContext();
+		return cachedChain;
+	}
+
+	const AudioContextClass = getAudioContextConstructor();
+	if (!AudioContextClass) {
+		logger.warn("Volume booster is not supported by this browser.");
+		return null;
+	}
+
+	try {
+		const context = new AudioContextClass();
+		const source = context.createMediaElementSource(video);
+		const gain = context.createGain();
+
+		source.connect(gain);
+		gain.connect(context.destination);
+
+		const chain: AudioChain = {
+			context,
+			source,
+			gain,
+			video,
+		};
+
+		audioChains.set(video, chain);
+		activeAudioChain = chain;
+		await resumeActiveContext();
+		return chain;
+	} catch (error) {
+		logger.error("Failed to initialize the volume booster audio chain:", error);
+		return null;
+	}
+}
+
+async function syncBoosterState() {
+	updateButtonState();
+
+	if (!config.get("player.settings.volumeBooster")) {
+		if (activeAudioChain) {
+			activeAudioChain.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+		}
+		return;
+	}
+
+	const chain = await ensureAudioChain();
+	if (!chain) {
+		return;
+	}
+
+	const multiplier = clampMultiplier(Number(config.get("player.settings.volumeBoosterMultiplier")));
+	chain.gain.gain.setValueAtTime(multiplier, chain.context.currentTime);
+}
+
+async function setBoosterEnabled(nextState: boolean) {
+	config.set("player.settings.volumeBooster", nextState);
+	updateButtonState();
+
+	if (!nextState) {
+		if (activeAudioChain) {
+			activeAudioChain.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+		}
+		return;
+	}
+
+	await syncBoosterState();
+}
+
+function mountBoosterStrip() {
+	const controls = videoPlayer.controls;
+	if (!controls) {
+		return;
+	}
+
+	if (!boosterStrip) {
+		boosterStrip = document.createElement("div");
+		boosterStrip.className = "yttweak-volume-booster-strip";
+
+		boosterButton = document.createElement("button");
+		boosterButton.type = "button";
+		boosterButton.className = "yttweak-volume-booster-button";
+		boosterButton.setAttribute("aria-label", "Toggle volume booster");
+		boosterButton.onclick = (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+
+			const nextState = !config.get("player.settings.volumeBooster");
+			void setBoosterEnabled(nextState);
+		};
+
+		const icon = document.createElement("span");
+		icon.className = "yttweak-volume-booster-icon";
+		icon.setAttribute("aria-hidden", "true");
+		icon.appendChild(createBoosterIcon());
+		boosterButton.appendChild(icon);
+		boosterStrip.appendChild(boosterButton);
+	}
+
+	const rightControls = controls.querySelector(".ytp-right-controls");
+	const speedStrip = controls.querySelector(".yttweak-speed-buttons");
+	const insertBeforeNode = speedStrip?.nextSibling || rightControls || null;
+
+	if (boosterStrip.parentElement !== controls) {
+		controls.insertBefore(boosterStrip, insertBeforeNode);
+	} else if (speedStrip && boosterStrip.previousSibling !== speedStrip) {
+		controls.insertBefore(boosterStrip, speedStrip.nextSibling || rightControls || null);
+	}
+
+	updateButtonState();
+}
+
+function initPlayer() {
+	if (playerBoundForBooster && playerBoundForBooster !== videoPlayer.videoStream) {
+		activeAudioChain?.gain.gain.setValueAtTime(1, activeAudioChain.context.currentTime);
+		activeAudioChain = null;
+	}
+
+	mountBoosterStrip();
+	videoPlayer.videoStream?.addEventListener("play", syncBoosterState);
+	videoPlayer.videoStream?.addEventListener("loadedmetadata", syncBoosterState);
+	videoPlayer.videoStream?.addEventListener("ended", syncBoosterState);
+	void syncBoosterState();
+}
+
+function refreshVolumeBoosterUi() {
+	mountBoosterStrip();
+	void syncBoosterState();
+}
+
+export default {
+	"player.ui.enableVolumeBooster": {
+		initPlayer,
+		enable() {
+			mountBoosterStrip();
+			updateButtonState();
+		},
+		disable() {
+			updateButtonState();
+		},
+		configUpdate(oldConfig, newConfig) {
+			const uiChanged = oldConfig["player.ui.enableVolumeBooster"] !== newConfig["player.ui.enableVolumeBooster"];
+			const enabledChanged = oldConfig["player.settings.volumeBooster"] !== newConfig["player.settings.volumeBooster"];
+			const multiplierChanged =
+				oldConfig["player.settings.volumeBoosterMultiplier"] !== newConfig["player.settings.volumeBoosterMultiplier"];
+
+			if (uiChanged || enabledChanged || multiplierChanged) {
+				refreshVolumeBoosterUi();
+			}
+
+			return false;
+		},
+		videoSrcChange() {
+			refreshVolumeBoosterUi();
+		},
+	},
+	"player.settings.volumeBooster": {
+		initPlayer,
+		enable() {
+			void syncBoosterState();
+		},
+		disable() {
+			void syncBoosterState();
+		},
+		configUpdate(oldConfig, newConfig) {
+			const multiplierChanged =
+				oldConfig["player.settings.volumeBoosterMultiplier"] !== newConfig["player.settings.volumeBoosterMultiplier"];
+
+			if (multiplierChanged) {
+				void syncBoosterState();
+			}
+
+			return false;
+		},
+		videoSrcChange() {
+			void syncBoosterState();
+		},
+	},
+} as Record<string, Plugin>;

--- a/src/inject/plugins/player-volumeBooster.ts
+++ b/src/inject/plugins/player-volumeBooster.ts
@@ -67,7 +67,7 @@ function updateButtonState() {
 
 	const isEnabled = config.get("player.settings.volumeBooster");
 	const multiplier = getConfiguredMultiplier();
-	const buttonText = `Volume booster ${isEnabled ? "on" : "off"} (${formatMultiplier(multiplier)}x)`;
+	const buttonText = `Volume booster ${isEnabled ? "on" : "off"} (${formatMultiplier(multiplier)}x)\n\n🖱Use the mouse wheel to control:\n - Increase by 0.25x upwards\n - Decrease by 0.25x downwards`;
 
 	boosterButton.classList.toggle("yttweak-volume-booster-active", isEnabled);
 	boosterButton.setAttribute("text", `${formatMultiplier(multiplier)}x`);

--- a/src/inject/style.scss
+++ b/src/inject/style.scss
@@ -3,6 +3,8 @@
 @use "./plugins/comment-nickname.scss";
 @use "./plugins/comment-translate.scss";
 @use "./plugins/player-function-buttons.scss";
+@use "./plugins/player-miniPlayer.scss";
 @use "./plugins/player-speedButton.scss";
 @use "./plugins/player-ui.scss";
+@use "./plugins/player-volumeBooster.scss";
 @use "./plugins/shorts-blocker.scss";


### PR DESCRIPTION
This adds a scroll mini player and a volume booster to the player.
Both features are configurable from settings, and the booster is available directly beside the speed buttons.
Also adds the missing `tsx` dependency used by the build script.